### PR TITLE
Fix typo and formatting on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### [Scene Graph](TP1/MySceneGraph.js)
 
-- A few complex elements (helm, masts, canons)
+- A few complex elements (helm, masts, cannons)
 - Use of all primitives
 - Use of different materials
 - Multiple cameras and lights

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # LAIG 2020/2021
 
 ## Group T03G09
-| Name             | Number    | E-Mail              |
-| ---------------- | --------- | ------------------  |
-| João Martins     | 201806436 | up201806436@fe.up.pt|
-| Ivo Saavedra     | 201707093 | up201707093@fe.up.pt|
 
-----
+| Name         | Number    | E-Mail               |
+| ------------ | --------- | -------------------- |
+| João Martins | 201806436 | up201806436@fe.up.pt |
+| Ivo Saavedra | 201707093 | up201707093@fe.up.pt |
+
+---
 
 ## Projects
 
@@ -17,28 +18,28 @@
 - Use of different materials
 - Multiple cameras and lights
 - Separated texture/material behavior into multiple files to make them
-independent between each other
+  independent between each other
 - Resistant parser
 - Scene
   - Pirate ship scene
   - [Scene XML](TP1/scenes/LAIG_TP1_XML_T3_G09_v1.xml)
 
------
+---
 
 ### [Scene Graph](TP2/MySceneGraph.js)
 
 - Resistant parser
 - Use of patches in flag and sail
 - Complex keyframe animations for ship and ball movement
-- Sprite animations when firing canons and keyframe animation
-to hide it afterwards
+- Sprite animations when firing canons and keyframe animation to hide it
+  afterwards
 - Use of barrel
 - Scene
   - Pirate ship scene
   - [Scene XML](TP2/scenes/LAIG_TP1_XML_T3_G09_v1.xml)
 
-----
+---
 
 ### [TP3 - ...](TP3)
-- (items briefly describing main strong points)
 
+- (items briefly describing main strong points)


### PR DESCRIPTION
- Fix a typo on the README: ~~canons~~ → cannons
- Add empty line after markdown headers